### PR TITLE
Only trigger the abort if there is already something loading

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -373,6 +373,7 @@ export class Viewer implements IDisposable {
     private readonly _imageProcessingConfigurationObserver: Observer<ImageProcessingConfiguration>;
     private _renderLoopController: Nullable<IDisposable> = null;
     private _modelInfo: Nullable<Model> = null;
+    private _cubeTexture: Nullable<CubeTexture> = null;
     private _skybox: Nullable<Mesh> = null;
     private _skyboxBlur: number = 0.3;
     private _skyboxTexture: Nullable<CubeTexture> = null;
@@ -999,8 +1000,8 @@ export class Viewer implements IDisposable {
             locks.push(this._loadSkyboxLock);
         }
 
-        const environmentAbortController = (this._loadEnvironmentAbortController = options.lighting ? new AbortController() : null);
-        const skyboxAbortController = (this._loadSkyboxAbortController = options.skybox ? new AbortController() : null);
+        const environmentAbortController = (this._loadEnvironmentAbortController = options.lighting && this._cubeTexture ? new AbortController() : null);
+        const skyboxAbortController = (this._loadSkyboxAbortController = options.skybox && this._cubeTexture ? new AbortController() : null);
 
         await AsyncLock.LockAsync(async () => {
             throwIfAborted(abortSignal, environmentAbortController?.signal, skyboxAbortController?.signal);
@@ -1024,6 +1025,7 @@ export class Viewer implements IDisposable {
             try {
                 if (url) {
                     const cubeTexture = CubeTexture.CreateFromPrefilteredData(url, this._scene);
+                    this._cubeTexture = cubeTexture;
 
                     if (options.lighting) {
                         this._reflectionTexture = cubeTexture;


### PR DESCRIPTION
If you use directly the `loadEnvironment` method without using the `environment` attribute, the abort method was being called regardless if there was actually something loading which displayed an error in the console.

To reproduce :
- remove the `environment` tag on the `babylon-viewer`
- add the following inside the `viewerReady` event listener :

```
viewerDetails.viewer.loadEnvironment("https://cdn.substance3d.com/v2/files/public/studio-white.env");
setTimeout(() => {
    viewerDetails.viewer.loadEnvironment("https://assets.babylonjs.com/environments/ulmerMuenster.env", { lighting: true, skybox: true });
    viewerDetails.viewer.loadEnvironment("https://cdn.substance3d.com/v2/files/public/studio-white.env", { lighting: true, skybox: true });
}, 500);
```

You should only see 1 error now intead of 2