### PR TITLE
Various fixes

### DIFF
--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
@@ -951,7 +951,7 @@ export const Configurator: FunctionComponent<{ viewerOptions: ViewerOptions; vie
     );
 
     const isEnvironmentLightingUrlValid = useMemo(() => {
-        return !lightingUrlConfig.configuredState || URL.canParse(lightingUrlConfig.configuredState) || lightingUrlConfig.configuredState === "auto";
+        return !lightingUrlConfig.configuredState || lightingUrlConfig.configuredState === "auto" || URL.canParse(lightingUrlConfig.configuredState);
     }, [lightingUrlConfig.configuredState]);
 
     const onEnvironmentLightingUrlChange = useCallback(
@@ -962,7 +962,7 @@ export const Configurator: FunctionComponent<{ viewerOptions: ViewerOptions; vie
     );
 
     const isEnvironmentSkyboxUrlValid = useMemo(() => {
-        return !skyboxUrlConfig.configuredState || URL.canParse(skyboxUrlConfig.configuredState);
+        return !skyboxUrlConfig.configuredState || skyboxUrlConfig.configuredState === "auto" || URL.canParse(skyboxUrlConfig.configuredState);
     }, [skyboxUrlConfig.configuredState]);
 
     const onEnvironmentSkyboxUrlChange = useCallback(

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1763,6 +1763,10 @@ export class Viewer implements IDisposable {
             import("core/Materials/Textures/renderTargetTexture"),
             import("core/Lights/Shadows/shadowGenerator"),
             import("core/Lights/Shadows/shadowGeneratorSceneComponent"),
+            // TODO: Why are these explicit imports needed, even though they are imported directly in shadowOnlyMaterial?
+            // Without these explicit imports, the shaders do not end up in the esm dist and we get a runtime error.
+            import("materials/shadowOnly/shadowOnly.vertex"),
+            import("materials/shadowOnly/shadowOnly.fragment"),
         ]);
 
         // cancel if the model is unloaded before the shadows are created

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1830,6 +1830,9 @@ export class Viewer implements IDisposable {
                 shouldRender: true,
             });
 
+            // Since the light is not applied to the meshes of the model (we only want shadows, not lighting),
+            // the ShadowGenerator's isReady will think everything is ready before it actually is. To account
+            // for this, explicitly wait for the first shadow map render to consider shadows in a ready state.
             generator.onAfterShadowMapRenderObservable.addOnce(() => {
                 newNormal.shouldRender = false;
             });

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1154,7 +1154,16 @@ export class Viewer implements IDisposable {
         if (model !== this._activeModelBacking) {
             this._activeModelBacking = model;
             this._updateLight();
-            this._updateShadows();
+            (async () => {
+                try {
+                    await this._updateShadows();
+                } catch (error) {
+                    // If _updateShadows was aborted (e.g. because a new update was requested before this one finished), we can just ignore the error.
+                    if (!(error instanceof AbortError)) {
+                        Logger.Error(error);
+                    }
+                }
+            })();
             this._applyAnimationSpeed();
             this._selectAnimation(0, false);
             this.onSelectedMaterialVariantChanged.notifyObservers();
@@ -2076,7 +2085,16 @@ export class Viewer implements IDisposable {
                 await Promise.all(newTexturePromises);
 
                 this._updateLight();
-                this._updateShadows();
+                (async () => {
+                    try {
+                        await this._updateShadows();
+                    } catch (error) {
+                        // If _updateShadows was aborted (e.g. because a new update was requested before this one finished), we can just ignore the error.
+                        if (!(error instanceof AbortError)) {
+                            Logger.Error(error);
+                        }
+                    }
+                })();
                 this.onEnvironmentChanged.notifyObservers();
             } catch (e) {
                 this.onEnvironmentError.notifyObservers(e);

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1520,7 +1520,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
 
         try {
             const options = { quality };
-            this._viewerDetails?.viewer.updateShadows(options);
+            await this._viewerDetails?.viewer.updateShadows(options);
         } catch (error) {
             // If loadEnvironment was aborted (e.g. because a new environment load was requested before this one finished), we can just ignore the error.
             if (!(error instanceof AbortError)) {

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-internal-modules
 import type { Nullable, Observable } from "core/index";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
-import type { CameraOrbit, EnvironmentOptions, HotSpot, ResetFlag, ShadowParams, ShadowQuality, ToneMapping, ViewerDetails, ViewerHotSpotResult } from "./viewer";
+import type { CameraOrbit, EnvironmentOptions, HotSpot, ResetFlag, ShadowQuality, ToneMapping, ViewerDetails, ViewerHotSpotResult } from "./viewer";
 import type { CanvasViewerOptions } from "./viewerFactory";
 
 import { LitElement, css, html } from "lit";

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -65,22 +65,19 @@ export async function CreateViewerForCanvas(
     options?: CanvasViewerOptions & { viewerClass?: new (...args: ConstructorParameters<typeof Viewer>) => Viewer }
 ): Promise<Viewer> {
     if (options) {
-        options = new Proxy(options, {
-            get(target, prop: keyof CanvasViewerOptions) {
-                // keyof CanvasViewerOptions only works for the first type or common keys.
-                // so we need to check if the prop is a WebGPUEngineOptions key.
-                const webGPUTarget = target as WebGPUEngineOptions;
-                const webGPUProp = prop as keyof WebGPUEngineOptions;
-                if (webGPUProp === "enableAllFeatures") {
-                    return webGPUTarget.enableAllFeatures ?? defaultCanvasViewerOptions.enableAllFeatures;
-                } else if (webGPUProp === "setMaximumLimits") {
-                    return webGPUTarget.setMaximumLimits ?? defaultCanvasViewerOptions.setMaximumLimits;
-                } else if (prop === "antialias") {
-                    return target.antialias ?? defaultCanvasViewerOptions.antialias;
-                } else if (prop === "adaptToDeviceRatio") {
-                    return target.adaptToDeviceRatio ?? defaultCanvasViewerOptions.adaptToDeviceRatio;
-                } else {
-                    return target[prop];
+        options = new Proxy(options as CanvasViewerOptions & EngineOptions & WebGPUEngineOptions, {
+            get(target, prop: keyof (CanvasViewerOptions & EngineOptions & WebGPUEngineOptions)) {
+                switch (prop) {
+                    case "antialias":
+                        return target.antialias ?? defaultCanvasViewerOptions.antialias;
+                    case "adaptToDeviceRatio":
+                        return target.adaptToDeviceRatio ?? defaultCanvasViewerOptions.adaptToDeviceRatio;
+                    case "enableAllFeatures":
+                        return target.enableAllFeatures ?? defaultCanvasViewerOptions.enableAllFeatures;
+                    case "setMaximumLimits":
+                        return target.setMaximumLimits ?? defaultCanvasViewerOptions.setMaximumLimits;
+                    default:
+                        return target[prop];
                 }
             },
         });

--- a/packages/tools/viewer/test/apps/web/index.html
+++ b/packages/tools/viewer/test/apps/web/index.html
@@ -80,7 +80,7 @@
         <div id="moreUpperPageContent" style="width: 100%; height: 200vh; display: none"></div>
         <div id="viewerContainer" style="width: 100vw; height: 100vh">
             <babylon-viewer
-                source="http://localhost:4000/glb/SheenChair.glb"
+                source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
                 animation-speed="1.5"
                 selected-animation="1"
                 camera-orbit="auto auto auto"
@@ -127,7 +127,8 @@
                         </svg>
                     </div>
                 </babylon-viewer-annotation>
-                <babylon-viewer-annotation hotspot="thruster"> </babylon-viewer-annotation>
+                <babylon-viewer-annotation hotspot="thruster">
+                </babylon-viewer-annotation>
                 <babylon-viewer-annotation hotspot="poi"></babylon-viewer-annotation>
             </babylon-viewer>
         </div>
@@ -372,7 +373,7 @@
             globalThis.onEnvironmentVisibility = () => {
                 const checked = document.querySelector("#environmentVisibilityInput").checked;
                 const viewer = viewerElement.viewerDetails.viewer;
-                viewer.loadEnvironment(checked ? "auto" : "none", { skybox: true });
+                checked ? viewer.loadEnvironment("auto", { skybox: true }) : viewer.resetEnvironment({ skybox: true });
             };
             globalThis.onShadowQuality = () => {
                 const value = document.querySelector("#shadowQualityInput").value;


### PR DESCRIPTION
- When testing in the configurator I found some corner case issues with `_updateEnvironment`. I went around and around trying to cover them but reasoning about the logic with the old code structure was challenging, so I ended up rewriting it in a way that I hope is easier to understand and more robust. The old structure of the code (prior to the shadows work) was just not conducive to changing the behavior of "auto" as we discussed, so I think in the end the restructuring was needed.
- Added some missing awaits.
- Fixed a Viewer Configurator bug that I found while testing the `_updateEnvironment` changes.
- Added some additional state and logic for continuing rendering the scene until the classic shadows have rendered once (otherwise they were not showing up for me until I moved the camera or otherwise caused the scene to render again).
- Got rid of some variables that were of type `any`.
- Replaced some non-null assertions with runtime checks.
- A few other small cosmetic or type related changes.

Can you re-test on your side and make sure these changes don't introduce any regressions for your scenarios?